### PR TITLE
hid the console behind the GUI

### DIFF
--- a/PSSU GUI.ps1
+++ b/PSSU GUI.ps1
@@ -33,6 +33,9 @@ The current features include:
 
 #>
 
+# Include Functions for hiding/showing the console in the background
+. .\lib\ToggleConsole.ps1
+
 Add-Type -assembly System.Windows.Forms
 [System.Windows.Forms.Application]::EnableVisualStyles()
 
@@ -180,6 +183,11 @@ foreach ($file in $NumScripts) {
 $btn_Run.Add_Click({ if ($this.Tag -ne $null) { start-process powershell.exe -verb $verb -argument "-noexit -nologo -noprofile -executionpolicy bypass -file `"$($this.Tag)`"" } })
 
 ###################################################################
+# Hide console (can't do this after the form is shown)
+###################################################################
+Hide-Console
+
+###################################################################
 # This section checks if dynamic button panel has a scroll bar and
 # changes the sizes and positioning
 ###################################################################
@@ -203,3 +211,4 @@ $pnl_Logo.controls.AddRange(@($img_Logo))
 
 $Form.Controls.Add($flowlayoutpanel1)
 $Form.ShowDialog()
+

--- a/lib/ToggleConsole.ps1
+++ b/lib/ToggleConsole.ps1
@@ -1,0 +1,36 @@
+﻿# .Net methods for hiding/showing the console in the background
+Add-Type -Name Window -Namespace Console -MemberDefinition '
+[DllImport("Kernel32.dll")]
+public static extern IntPtr GetConsoleWindow();
+
+[DllImport("user32.dll")]
+public static extern bool ShowWindow(IntPtr hWnd, Int32 nCmdShow);
+'
+
+function Show-Console
+{
+    $consolePtr = [Console.Window]::GetConsoleWindow()
+
+    # Hide = 0,
+    # ShowNormal = 1,
+    # ShowMinimized = 2,
+    # ShowMaximized = 3,
+    # Maximize = 3,
+    # ShowNormalNoActivate = 4,
+    # Show = 5,
+    # Minimize = 6,
+    # ShowMinNoActivate = 7,
+    # ShowNoActivate = 8,
+    # Restore = 9,
+    # ShowDefault = 10,
+    # ForceMinimized = 11
+
+    [Console.Window]::ShowWindow($consolePtr, 4)
+}
+
+function Hide-Console
+{
+    $consolePtr = [Console.Window]::GetConsoleWindow()
+    #0 hide
+    [Console.Window]::ShowWindow($consolePtr, 0)
+}


### PR DESCRIPTION
I basically just copied code from elsewhere to hide the powershell windows behind the GUI.
Not really a functional improvement, but a small nugget of functionality even so.